### PR TITLE
予約画面カレンダーと１週間表示作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,12 @@ gem 'jquery-rails'
 gem 'turbolinks',   '~> 5'
 gem 'jbuilder',     '~> 2.5'
 
+# 日付と時間のフォーム用
+gem 'bootstrap3-datetimepicker-rails', '~> 4.17.47'
+gem 'momentjs-rails', '>= 2.9.0'
+
+gem 'font-awesome-rails', '~> 4.7.0'
+
 group :development, :test do
   gem 'sqlite3', '1.3.13'
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
       sass (>= 3.3.4)
     bootstrap-will_paginate (1.0.0)
       will_paginate
+    bootstrap3-datetimepicker-rails (4.17.47)
+      momentjs-rails (>= 2.8.1)
     builder (3.2.3)
     byebug (11.0.1)
     coffee-rails (4.2.2)
@@ -64,6 +66,8 @@ GEM
     faker (1.7.3)
       i18n (~> 0.5)
     ffi (1.11.1)
+    font-awesome-rails (4.7.0.5)
+      railties (>= 3.2, < 6.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (0.9.5)
@@ -88,6 +92,8 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    momentjs-rails (2.20.1)
+      railties (>= 3.1)
     multi_json (1.13.1)
     nio4r (2.4.0)
     nokogiri (1.10.3)
@@ -178,12 +184,15 @@ DEPENDENCIES
   bcrypt
   bootstrap-sass
   bootstrap-will_paginate
+  bootstrap3-datetimepicker-rails (~> 4.17.47)
   byebug
   coffee-rails (~> 4.2)
   faker
+  font-awesome-rails (~> 4.7.0)
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  momentjs-rails (>= 2.9.0)
   pg (= 0.20.0)
   puma (~> 3.7)
   rails (~> 5.1.6)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,8 @@
 //= require jquery
 //= require bootstrap
 //= require turbolinks
+//= require moment
+//= require moment/ja
+//= require bootstrap-datetimepicker
 //= require_tree .
+

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,6 +10,8 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
+ *= require bootstrap-datetimepicker
+ *= require font-awesome
  *= require_tree .
  *= require_self
  */

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -90,3 +90,5 @@ li .nav-right:hover {
   -webkit-box-sizing: border-box;
   box-sizing:         border-box;
 }
+
+

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,3 +1,40 @@
 // Place all the styles related to the Users controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+
+//user show
+
+.resavation_week_form{
+  float:left;
+  margin-right:30px;
+}
+
+.prev,.next{
+  font-size:20px;
+  padding:5px 10px 5px 10px;
+  border:1px solid #BBBBBB;
+  border-radius:5px;
+}
+
+.resavation_week{
+  margin:0px 10px 0px 10px;
+}
+
+.resavation_calendar{
+  background-color:#CCCCCC;
+  width:100px;
+}
+
+.resavation_calendar_btn{
+  background-color:#CCCCCC;
+  border:1px solid #CCCCCC;
+}
+
+.input-group-addon:last-child{
+  border-radius: 5px;
+}
+
+.space{
+  height:500px;
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,18 @@ class UsersController < ApplicationController
   end
   
   def show
+    @first_day = Date.current
+  end
+  
+  def change_show 
+    if params[:prev]
+       day = params[:prev]
+    elsif params[:next]
+       day = params[:next]
+    end  
+    if day
+       @first_day = day.to_date
+    end
   end
   
   def create

--- a/app/views/users/_resavation_week.html.erb
+++ b/app/views/users/_resavation_week.html.erb
@@ -1,0 +1,3 @@
+<span class="prev"><%= link_to "<",change_show_user_path(current_user,prev:@first_day.ago(7.days)),remote:true %></span>
+<span class="resavation_week"><%= l(@first_day, format: :long) %>~<%= l(@first_day.since(6.days).to_date, format: :long) %></span>
+<span class="next"><%= link_to ">",change_show_user_path(current_user,next:@first_day.since(7.days)),remote:true %></span>

--- a/app/views/users/change_show.js.erb
+++ b/app/views/users/change_show.js.erb
@@ -1,0 +1,1 @@
+$(".resavation_week_form").html("<%= escape_javascript(render :partial => "resavation_week") %>");

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,7 +12,18 @@
 <p>※受付締切：当日の2時間前まで</p>
 <p>※受付開始：90日前の0時から</p>
 
+
 <p>予約日時を選択してください。</p>
+<div class="resavation_week_form">
+  <%= render 'resavation_week' %>
+</div>
+<div class="input-group date datepicker">
+  <input type="hidden">
+  <span class="input-group-addon resavation_calendar">
+    <button type="button" class="resavation_calendar_btn">カレンダー</button>
+  </span>
+</div>
+
 <table>
     
 </table>
@@ -23,3 +34,28 @@
 
 <h5>◯◯様　予約状況一覧</h5>
 
+<script>
+
+$(function(){
+  $('.datepicker').datetimepicker({
+    format : "YYYY/MM/DD",
+    defaultDate : new Date(),
+    icons: {
+      previous: "fa fa-arrow-left",
+      next: "fa fa-arrow-right"
+    }
+  });
+  
+   $('.datepicker').on('dp.change', function (e) {
+       var date = String(e.date).split(" ")[3]+"-"+(new Date(e.date).getMonth() + 1)+"-"+String(e.date).split(" ")[2];
+         $.ajax({
+                url:'/users/<%= current_user.id %>/change_show',
+                type:'GET',
+                data:{
+                    'prev':date
+                }
+            });
+    });
+});    
+    
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,7 @@ Rails.application.routes.draw do
   post   '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'
   
-  resources :users
-  end
+  resources :users do
+    get "change_show", on: :member
+  end 
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,6 @@ User.create!(name: "わいサンプルさん",
              email: "sample@email.com",
              password: "password",
              password_confirmation: "password")
-User.create!(name: "test",
-             email: "test@email.com",
-             password: "test",
-             password_confirmation: "test")
+
+Operation.create!(seat: 5,
+                  all_seat: 30)


### PR DESCRIPTION
内容：予約画面でのカレンダーおよび１週間の日付表示

詳細：bootstrapを用いてカレンダーボタンおよびボタン押下時にカレンダーを表示
　　　（カレンダー を使用するため、bootstrap-datetimepicker,font-awesomeのgemファイルを 
            追加しています。）
　　　１週間の日付を表示し、＜＞リンクを押下時に、１週間日付を変更
　　　カレンダーの日付をクリックすると、クリックした日から１週間分の日付を表示
　　　（＜＞リンクおよびカレンダー の日付をクリック時の日付の切り替えは、仮にremote:trueお 
            よびajaxを用いて、js方式で切り替えています
　　　　１週間分の予約表示画面が出来次第、最終的な調整をしたいと思います。）