### PR TITLE
時間のバリデーション設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include SessionsHelper
-  
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -18,11 +18,6 @@ class ReservationsController < ApplicationController
     @user = User.find(params[:user_id])
     @reservation = Reservation.find(params[:id])
     if @reservation.update_attributes(reservation_params)
-    # if reservations_invalid?
-    #   reservation_params.each do |id,item|
-    #     reservation = Reservation.find(id)
-    #     reservation.update_attributes!(item)
-    #   end
       flash[:success] = "#{@user.name}様の予約情報を更新しました。"
     else
       flash[:danger] = "#{@user.name}様の更新は失敗しました。"

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -1,18 +1,2 @@
 module ReservationsHelper
-  
-  def reservations_invalid?
-    reservations = true
-    reservation_params.each do |id,item|
-      if item[:started_at].blank? && item[:finished_at].blank?
-        next
-      elsif item[:started_at].blank? || item[:finished_at].blank?
-        reservations = false
-        break
-      elsif item[:started_at] > item[:finished_at]
-        reservations = false
-        break
-      end
-    end
-    return reservations
-  end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -3,4 +3,25 @@ class Reservation < ApplicationRecord
   
   validates :meeting_on, presence: true
   validates :telmail_name, length: { maximum: 50 }
+  
+  # 開始時間のみの更新は無効
+  validate :only_started_at_or_only_finished_at_not_update
+    # 終了時間のみの更新は無効
+  validate :finished_at_is_invalid_without_a_started_at
+  # 開始・終了時間どちらも存在する時、開始時間より早い終了時間は無効
+  validate :started_at_than_finished_at_fast_if_invalid
+  
+  def only_started_at_or_only_finished_at_not_update
+    errors.add(:started_at, "のみの更新は無効です") if started_at.present? && finished_at.blank?
+  end
+
+  def finished_at_is_invalid_without_a_started_at
+    errors.add(:finished_at, "のみの更新は無効です") if started_at.blank? && finished_at.present?
+  end
+
+  def started_at_than_finished_at_fast_if_invalid
+    if started_at.present? && finished_at.present?
+      errors.add(:started_at, "より早い退勤時間は無効です") if started_at > finished_at
+    end
+  end
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -57,7 +57,7 @@
                           <!-- MS予約情報モーダル -->
                           <li>
                             <%= link_to "#{l(reservation.started_at, format: :short)}
-                                ~#{l(reservation.started_at, format: :short)}",
+                                ~#{l(reservation.finished_at, format: :short)}",
                                 edit_user_reservation_path(user, reservation),
                                 remote: true %>
                           </li>


### PR DESCRIPTION
> 概要
- ユーザー一覧の表示部分の修正
- 予約更新処理のバリデーションを設定
・開始時間のみの更新ができない
・終了時間のみの更新ができない
・終了時間が開始時間よりも早い更新ができない