### PR TITLE
タイムスケジュール表のレイアウトおよび予約済みデータの修正

### DIFF
--- a/app/assets/stylesheets/reservations.scss
+++ b/app/assets/stylesheets/reservations.scss
@@ -2,15 +2,30 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-
 /* reservation page */
+
+/*スクロールバーの幅*/
+::-webkit-scrollbar {
+    width: 15px;
+}
+
+/*スクロールバーのつまみ*/
+::-webkit-scrollbar-thumb {
+  border-radius: 30px;
+  background: #EEEEEE;
+}
+
+.reservation_schedule_form{
+  border: 0.5px solid #AAAAAA;
+}
 
 .reservation_week_form_table_body{
 	overflow: auto;
-  scroll-snap-type: y mandatory;
   height:700px;
-  border-right:1px solid #AAAAAA;
-  border-bottom:1px solid #AAAAAA;
+}
+
+.reservation_week_form_table{
+  border-bottom:0.5px solid #AAAAAA;
 }
 
 ul.time-field {
@@ -25,23 +40,28 @@ ul.time-field {
 
 .week-day-th {
   height: 35px;
-  min-width: 100px;
+  min-width: 80px;
   &:last-child {
     min-width: 16px;
+    border-left:0.5px solid #AAAAAA;
   }
 }
 
 .week-day-td {
   height: 35px;
-  width:120px;
+  width:145px;
   text-align:center;
+  border-left:0.5px solid #AAAAAA;
 }
 
 .time-schedule {
-  width: 120px;
+  width:145px;
   padding: 0;
   position:relative;
-  
+  border-left:0.5px solid #AAAAAA;
+  &:last-child {
+    border-right:0.5px solid #AAAAAA;
+  }
   ul {
     list-style: none;
     padding: 0;
@@ -99,23 +119,17 @@ ul.time-field {
 }
 
 .can_not_reservation{
- div{
-   background-color:#EEEEEE;
- }
+  div{
+    background-color:#EEEEEE;
+  }
 }
 
 .text-color{
   color:black;
 }
 
-table{
-  width: 100%;
-}
-
-.w-10 {
-  width: 10%;
-}
-
-.w-1{
-  width: 1%;
+@media screen and (max-width: 991px) {
+ .reserved{
+    font-size: 75%;
+  }
 }

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -38,7 +38,6 @@ class ReservationsController < ApplicationController
   def update
     @user = User.find(params[:user_id])
     @reservation = Reservation.find(params[:id])
-    render plain:reservation_params.inspect
     if @reservation.update_attributes(reservation_params)
       flash[:success] = "#{@user.name}様の予約情報を更新しました。"
     else

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -38,6 +38,7 @@ class ReservationsController < ApplicationController
   def update
     @user = User.find(params[:user_id])
     @reservation = Reservation.find(params[:id])
+    render plain:reservation_params.inspect
     if @reservation.update_attributes(reservation_params)
       flash[:success] = "#{@user.name}様の予約情報を更新しました。"
     else

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -26,14 +26,11 @@ module ReservationsHelper
   end
   
   def get_position(started_at,finished_at,week_day)
-    
     if Date.parse(started_at.to_s) == Date.parse(finished_at.to_s) || Date.parse(started_at.to_s) == week_day
        time = ((started_at - week_day.midnight)/60/60)
        (time/24.to_f*1776) + 22 
     elsif Date.parse(finished_at.to_s) == week_day || (Date.parse(finished_at.to_s) > week_day && Date.parse(started_at.to_s) < week_day)
       22
-    else
-  
     end
   end
 end

--- a/app/views/users/_reservation_week_tabale_body.html.erb
+++ b/app/views/users/_reservation_week_tabale_body.html.erb
@@ -1,5 +1,5 @@
 <!-- 7回繰り返す -->
-<table border="1" style="border-collapse: collapse" bordercolor="#AAAAAA">
+<table border="0" style="border-collapse: collapse">
   <tbody>
     <tr>
       <th class="week-day-th w-10">
@@ -35,13 +35,13 @@
               <% top_position = get_position(reservation.started_at,reservation.finished_at,week_day) %>
               <% if current_user.admin? || (!current_user.admin && current_user.id == reservation.user_id) %>
                 <%= link_to(user_reservation_url(@user,reservation),remote:true,class: 'text-color') do %>
-                  <div class="reserved text-center" style="height:<%= reservation_height %>px; top:<%= top_position %>px;">
+                  <div class="reserved text-center text-truncate" style="height:<%= reservation_height %>px; top:<%= top_position %>px;">
                     <%= reservation.user.name %>様</br>
                     <%= l(reservation.started_at,format: :time) %> ~ <%= l(reservation.finished_at,format: :time) %>
                   </div>
                 <% end %>
               <% else %>
-                <div class="reserved" style="height:<%= reservation_height %>px; top:<%= top_position %>px;">
+                <div class="reserved text-center" style="height:<%= reservation_height %>px; top:<%= top_position %>px;">
                   <%= l(reservation.started_at,format: :time) %> ~ <%= l(reservation.finished_at,format: :time) %>
                 </div>
               <% end %>
@@ -49,7 +49,6 @@
           <% end %>
         </td>
       <% end %>
-      <td class="week-day-th w-1"></td>
     </tr>
  </tbody>
 </table>

--- a/app/views/users/_reservation_week_tabale_th.html.erb
+++ b/app/views/users/_reservation_week_tabale_th.html.erb
@@ -1,4 +1,4 @@
-<table border="1" style="border-collapse: collapse" bordercolor="#AAAAAA">
+<table border="0" style="border-collapse: collapse">
   <thead>
     <tr>
       <th class="week-day-th w-10"></th>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -45,14 +45,14 @@
       <p>予約できません</p>
     </div>
   </div>
-  <div class="table-responsive rounded rounded-lg">
-  <div class="reservation_week_form_table">
-    <%= render 'reservation_week_tabale_th' %>
+  <div class="reservation_schedule_form table-responsive rounded rounded-lg">
+    <div class="reservation_week_form_table">
+      <%= render 'reservation_week_tabale_th' %>
+    </div>
+    <div class="reservation_week_form_table_body border-right-0">
+      <%= render 'reservation_week_tabale_body' %>
+    </div>
   </div>
-  <div class="reservation_week_form_table_body border-right-0">
-    <%= render 'reservation_week_tabale_body' %>
-  </div>
-  
 </div>
 <script>
 


### PR DESCRIPTION
内容：ミーティング表の角がかけている部分の手直し
　　　ミーティング表の曜日と時間部分の線のズレの手直し
　　　スクロールバーのカスタマイズ
　　　ミーティング表の予約済みデータの表示の件で、名前が長い場合にセルからはみ出る件について
　　　はみ出る部分は非表示としました。
　　　現在時刻が予約済みの時間だった場合は、予約済みの表示が消える件について修正しました。