### PR TITLE
ユーザー登録画面のエラーが複数ある場合の表示を整える（不具合No.9）

### DIFF
--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -2,11 +2,11 @@
   <div id="error_explanation">
     <div class="alert alert-danger">
       入力エラーが<%= @user.errors.count %>件ありました。
+      <ul>
+        <% @user.errors.full_messages.each do |msg| %>
+          <li class="text-left"><%= msg %></li>
+        <% end %>
+      </ul>
     </div>
-    <ul>
-    <% @user.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
-    <% end %>
-    </ul>
   </div>
 <% end %>


### PR DESCRIPTION
ユーザー登録画面にて、バリデーションエラーが表示された場合のレイアウトを調整しました。