### PR TITLE
ユーザー登録画面のエラーメッセージ調整・入力文字数制限追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,15 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum: 6, maximum: 20 },
                     format: { with: VALID_PASSWORD_REGEX }
   
+  validate :vali_test
+  
+  def vali_test
+    if errors[:password].any?
+      errors.messages.delete(:password) 
+      errors.add(:password, "は、半角英字で大文字1文字以上を含む、6文字以上20文字以内を入力してください。") 
+    end
+  end
+
   # 渡された文字列のハッシュ値を返します。
   def User.digest(string)
     cost = 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,12 +14,24 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum: 6, maximum: 20 },
                     format: { with: VALID_PASSWORD_REGEX }, allow_nil: true
   
-  validate :vali_test
+  validate :email_error_msg_make
+  validate :password_error_msg_make
   
-  def vali_test
+  def email_error_msg_make
+    if errors[:email].any?
+      errors.full_messages.each do |msg|
+        if msg == "Emailを入力してください"
+          errors.messages.delete(:email)
+          errors.add(:email, "を入力してください")
+        end
+      end
+    end
+  end
+  
+  def password_error_msg_make
     if errors[:password].any?
       errors.messages.delete(:password) 
-      errors.add(:password, "は、半角英数字で大文字1文字以上を含む、6文字以上20文字以内で入力してください。") 
+      errors.add(:password, "は、半角英数字で大文字1文字以上を含む、6文字以上20文字以内で入力してください") 
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   def vali_test
     if errors[:password].any?
       errors.messages.delete(:password) 
-      errors.add(:password, "は、半角英字で大文字1文字以上を含む、6文字以上20文字以内を入力してください。") 
+      errors.add(:password, "は、半角英数字で大文字1文字以上を含む、6文字以上20文字以内で入力してください。") 
     end
   end
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -2,19 +2,19 @@
   <%= render 'shared/error_messages', object: @user %>
     <div class="form-group row">
       <%= f.label :name, class: "label-login col-2 offset-2 lead text-right mr-4" %>
-      <%= f.text_field :name, class: 'form-control col-6', placeholder: "名前" %>
+      <%= f.text_field :name, class: 'form-control col-6', maxlength: "50", placeholder: "名前" %>
     </div>
     <div class="form-group row">
       <%= f.label :email, class: "label-login col-2 offset-2 lead text-right mr-4" %>
-      <%= f.email_field :email, class: 'form-control col-6', placeholder: "メールアドレス" %>
+      <%= f.email_field :email, class: 'form-control col-6', maxlength: "100", placeholder: "メールアドレス" %>
     </div>
     <div class="form-group row">
       <%= f.label :password, class: "label-login col-2 offset-2 lead text-right mr-4" %>
-      <%= f.password_field :password, class: 'form-control col-6', placeholder: "パスワード" %>
+      <%= f.password_field :password, class: 'form-control col-6', maxlength: "20", placeholder: "パスワード" %>
     </div>
     <div class="form-group row">
       <%= f.label :password_confirmation, class: "label-login col-3 offset-1 lead text-right mr-4" %>
-      <%= f.password_field :password_confirmation, class: 'form-control col-6', placeholder: "パスワード再入力" %>
+      <%= f.password_field :password_confirmation, class: 'form-control col-6', maxlength: "20", placeholder: "パスワード再入力" %>
     </div>
     <%= f.submit yield(:button_text), class: "btn btn-primary col-2 offset-0 shadow mt-3" %>
 <% end %>


### PR DESCRIPTION
不具合管理表No.23対応
・ユーザー登録画面の入力文字数制限追加
・emailの内容が被るエラーメッセージを単一に調整
・passwordのバリデーションエラーメッセージを変更