### PR TITLE
パスワードのバリデーションと各ページへのアクセス制御を修正

### DIFF
--- a/app/controllers/operations_controller.rb
+++ b/app/controllers/operations_controller.rb
@@ -1,5 +1,6 @@
 class OperationsController < ApplicationController
-   before_action :admin_user, only: [:edit]
+  before_action :logged_in_user, only: [:edit]
+  before_action :admin_user, only: [:edit]
     
   def edit
     @operation = Operation.find(1)
@@ -21,6 +22,14 @@ class OperationsController < ApplicationController
 
     def operation_params
       params.require(:operation).permit(:seat,:all_seat)
+    end
+    
+    def logged_in_user
+      unless logged_in?
+        store_location
+        flash[:danger] = "ログインしてください。"
+        redirect_to root_path
+      end
     end
     
     def admin_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,8 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:show, :index]
+  before_action :correct_user,   only: [:show]
+  before_action :admin_user,     only: [:index, :edit_info, :update_info]
+  before_action :correct_or_admin_user, only: [:destroy]
   
   def new
     @user = User.new
@@ -71,5 +75,32 @@ class UsersController < ApplicationController
       @reservations = Reservation.where("finished_at > ?",Time.zone.now)
       @times = 48.times.map.each_with_index {|i| Time.parse("0:00")+30.minutes*i}
       @time_number = 24.times.map.each_with_index {|i| l(Time.parse("0:00")+1.hours*i,format: :shorttime)}
+    end
+    
+  # beforeアクション
+
+    # ログイン済みユーザーか確認
+    def logged_in_user
+      unless logged_in?
+        store_location
+        flash[:danger] = "ログインしてください。"
+        redirect_to root_path
+      end
+    end
+
+    # 正しいユーザーかどうか確認
+    def correct_user
+      @user = User.find(params[:id])
+      redirect_to(root_path) unless current_user?(@user)
+    end
+    
+    def admin_user
+      redirect_to(root_path) unless current_user.admin?
+    end
+    
+    # 正しいユーザー、または、管理者ユーザーかどうか確認
+    def correct_or_admin_user
+      @user = User.find(params[:id])
+      redirect_to(root_path) unless current_user?(@user) or current_user.admin?
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: true
   has_secure_password
-  VALID_PASSWORD_REGEX = /\A(?=.*?[A-Z])[a-zA-Z\d]+\z/
+  VALID_PASSWORD_REGEX = /\A[a-zA-Z\d]+\z/
   validates :password, presence: true, length: { minimum: 6, maximum: 20 },
                     format: { with: VALID_PASSWORD_REGEX }, allow_nil: true
   
@@ -31,7 +31,7 @@ class User < ApplicationRecord
   def password_error_msg_make
     if errors[:password].any?
       errors.messages.delete(:password) 
-      errors.add(:password, "は、半角英数字で大文字1文字以上を含む、6文字以上20文字以内で入力してください") 
+      errors.add(:password, "は、半角英数字で6文字以上20文字以内で入力してください") 
     end
   end
 


### PR DESCRIPTION
不具合管理表のNo.21～23を対応
・新規登録画面でパスワードに大文字の半角英字が含まれてなくても登録可に変更
・未ログイン時に、各ページにアクセスできないように修正
・ログインユーザー以外のミーティングスペース予約画面にアクセスできないように修正
