### PR TITLE
ミーティング予約を削除した時の遷移先を各ページごとに調整

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -65,7 +65,7 @@ class ReservationsController < ApplicationController
     @reservation = Reservation.find(params[:id])
     Reservation.find(params[:id]).destroy
     flash[:success] = "削除しました。"
-    if params[:commit] == "削除"
+    if params[:from_page] == "Users"
       redirect_to users_url(@user)
     else
       redirect_to user_url(@user)

--- a/app/views/reservations/_edit.html.erb
+++ b/app/views/reservations/_edit.html.erb
@@ -41,7 +41,7 @@
             キャンセル
           </button>
           <%= f.submit yield(:button_text), class: "btn btn-primary px-4 mx-3" %>
-          <%= link_to "削除", user_reservation_path(@user, @reservation), method: :delete,
+          <%= link_to "削除", user_reservation_path(@user, @reservation, from_page: "Users"), method: :delete,
                 data: { confirm: "#{@user.name}様の予約情報を削除してよろしいですか？" }, class: "btn btn-danger px-4 mx-3" %>
         </span>
       </div><!-- /.modal-footer -->

--- a/app/views/reservations/_show_user_reservation.html.erb
+++ b/app/views/reservations/_show_user_reservation.html.erb
@@ -41,7 +41,7 @@
           <button type="button" class="btn btn-secondary mx-3" data-dismiss="modal">
             キャンセル
           </button>
-          <%= link_to "削除！", user_reservation_path(@user, @reservation), method: :delete,
+          <%= link_to "削除", user_reservation_path(@user, @reservation), method: :delete,
                 data: { confirm: "#{@user.name}様の予約情報を削除してよろしいですか？" }, class: "btn btn-danger px-4 mx-3" %>
         </span>
       </div><!-- /.modal-footer -->


### PR DESCRIPTION
それぞれのページでミーティング予約を削除した場合に、元通りのページにリダイレクトするように修正