### PR TITLE
タイムスケジュール表レイアウト修正

### DIFF
--- a/app/assets/stylesheets/reservations.scss
+++ b/app/assets/stylesheets/reservations.scss
@@ -4,17 +4,6 @@
 
 /* reservation page */
 
-/*スクロールバーの幅*/
-::-webkit-scrollbar {
-    width: 15px;
-}
-
-/*スクロールバーのつまみ*/
-::-webkit-scrollbar-thumb {
-  border-radius: 30px;
-  background: #EEEEEE;
-}
-
 .reservation_schedule_form{
   border: 0.5px solid #AAAAAA;
 }
@@ -25,6 +14,8 @@
 }
 
 .reservation_week_form_table{
+  width:100%;
+  padding-right:15px;
   border-bottom:0.5px solid #AAAAAA;
 }
 
@@ -41,10 +32,6 @@ ul.time-field {
 .week-day-th {
   height: 35px;
   min-width: 80px;
-  &:last-child {
-    min-width: 16px;
-    border-left:0.5px solid #AAAAAA;
-  }
 }
 
 .week-day-td {
@@ -52,6 +39,9 @@ ul.time-field {
   width:145px;
   text-align:center;
   border-left:0.5px solid #AAAAAA;
+  &:last-child {
+    border-right:0.5px solid #AAAAAA;
+  }
 }
 
 .time-schedule {
@@ -131,5 +121,36 @@ ul.time-field {
 @media screen and (max-width: 991px) {
  .reserved{
     font-size: 75%;
+  }
+ .week-day-th {
+    min-width: 50px;
+ }
+}
+
+@media screen and (max-device-width: 1024px) {
+ .reservation_week_form_table{
+    padding-right:initial;
+ }
+ .week-day-td {
+   &:last-child {
+     border-right:none;
+   }
+ }
+ .time-schedule {
+    &:last-child {
+      border-right:none;
+    }
+ }
+}
+
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+   _::-webkit-full-page-media, _:future, :root .reservation_week_form_table {
+        padding-right:15px;
+    }
+}
+
+@-moz-document url-prefix(){
+  .reserved{
+    border-left:0.5px solid #AAAAAA;
   }
 }

--- a/app/views/users/_reservation_week_tabale_body.html.erb
+++ b/app/views/users/_reservation_week_tabale_body.html.erb
@@ -1,8 +1,8 @@
 <!-- 7回繰り返す -->
-<table border="0" style="border-collapse: collapse">
-  <tbody>
+<table>
+  <tbody class="d-block">
     <tr>
-      <th class="week-day-th w-10">
+      <td class="week-day-th">
         <div>
           <ul class="time-field text-center">
             <% @time_number.each do |time_number| %>
@@ -10,7 +10,7 @@
             <% end %>
           </ul>
         </div>
-      </th>
+      </td>
       <% @week_day.each do |week_day| %>
         <td class="time-schedule">
           <div class="top_vacant"></div>

--- a/app/views/users/_reservation_week_tabale_th.html.erb
+++ b/app/views/users/_reservation_week_tabale_th.html.erb
@@ -1,11 +1,10 @@
 <table border="0" style="border-collapse: collapse">
   <thead>
     <tr>
-      <th class="week-day-th w-10"></th>
+      <th class="week-day-th"></th>
         <% @week_day.each do |week_day| %>
           <td class="week-day-td <%= get_color(week_day) %>"><%= l(week_day, format: :long_mini) %></td>
         <% end %>
-      <th class="week-day-th w-1"></th>
     </tr>
  </thead>
 </table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -74,6 +74,14 @@ $(function(){
                 }
             });
     });
+　var ua = navigator.userAgent.toLowerCase();
+ 
+　isMac =　ua.indexOf('windows') > -1;
+
+  if(isMac && window.matchMedia( "(min-device-width: 1025px)" ).matches) {
+    $('.reservation_week_form_table').css('padding-right',"16.9px");
+  }
+  
 });    
     
 </script>


### PR DESCRIPTION
タイムアウトスケジュールレイアウト修正
スマホ 画面で確認時、スクロールの表示変化によるレイアウト崩れの修正
mac、windowsともにchrome、safari、firefoxにて確認を行っております。
（すみませんが、IEについては、まだ未確認です。）