### PR TITLE
予約状況一覧のカード幅を画面サイズに調整

### DIFF
--- a/app/assets/stylesheets/reservations.scss
+++ b/app/assets/stylesheets/reservations.scss
@@ -154,3 +154,7 @@ ul.time-field {
     border-left:0.5px solid #AAAAAA;
   }
 }
+
+@media screen and (min-width:767px) {
+  .card-width { width: 400px; }
+}

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,7 @@
     <h2 class="d-inline-block border-bottom border-dark mb-5">RESERVATION</h2>
     <p class="mb-0">ご自身のMeeting Spaceの予約状況を確認することができます。</p>
     <p class="mb-5">また、カレンダーで日時を選択することで、Meeting Spaceを予約することができます。</p>
-    <div class="card border-light vw-100 mx-auto">
+    <div class="card border-light card-width mx-auto">
       <strong class="card-header">
         <%= @user.name %>様　予約状況一覧
       </strong>


### PR DESCRIPTION
不具合管理表No.50
予約状況一覧のカード幅を、予約日時とゴミ箱アイコンの幅が広くなりすぎない程度に調整しました。
デバイスによって見えかたが変わるので、
herokuにpush後、不備がないか確認が必要だと思います！