### PR TITLE
ミーティングスペース不具合修正

### DIFF
--- a/app/assets/stylesheets/reservations.scss
+++ b/app/assets/stylesheets/reservations.scss
@@ -9,7 +9,7 @@
 }
 
 .reservation_week_form_table_body{
-	overflow: auto;
+	overflow-y: scroll;
   height:700px;
 }
 
@@ -72,7 +72,7 @@ ul.time-field {
 }
 
 .post_time{
-  background-color:#EEEEEE;
+  background-color:#DDDDDD;
 }
 .week_today_color{
   background-color:#00BB00;
@@ -82,14 +82,14 @@ ul.time-field {
 .reserved{
   position:absolute;
   width:100%;
-  background-color:#EEEEEE;
+  background-color:#DDDDDD;
   border-bottom: solid 1px #AAAAAA;
   font-size: 80%;
 }
 
 .top_vacant{
   height:22px;
-  background-color:#EEEEEE;
+  background-color:#DDDDDD;
 }
 
 .reservation_status_list{

--- a/app/views/users/_reservation_week.html.erb
+++ b/app/views/users/_reservation_week.html.erb
@@ -1,3 +1,3 @@
-<%= link_to "<",change_show_user_path(current_user,prev:@first_day.ago(7.days)),remote:true, class: "btn btn-outline-secondary col-1" %>
-<span class="reservation_week text-wrap font-weight-lighter col-10 mx-0 px-0 text-center my-auto col-md-5"><%= l(@first_day, format: :long) %>~<%= l(@first_day.since(6.days).to_date, format: :long) %></span>
-<%= link_to ">",change_show_user_path(current_user,next:@first_day.since(7.days)),remote:true, class: "btn btn-outline-secondary col-1" %>
+<%= link_to "<",change_show_user_path(current_user,prev:@first_day.ago(7.days)),remote:true, class: "btn btn-outline-secondary" %>
+<span class="reservation_week text-wrap font-weight-lighter mx-1 px-1 text-center my-auto"><%= l(@first_day, format: :short_day) %>~<%= l(@first_day.since(6.days).to_date, format: :short_day) %></span>
+<%= link_to ">",change_show_user_path(current_user,next:@first_day.since(7.days)),remote:true, class: "btn btn-outline-secondary" %>

--- a/app/views/users/_reservation_week_tabale_body.html.erb
+++ b/app/views/users/_reservation_week_tabale_body.html.erb
@@ -17,7 +17,7 @@
           <ul>
             <% @times.each do |time| %>
               <% datetime = Time.zone.local(week_day.year,week_day.month,week_day.day,time.hour,time.min) %> 
-              <% if datetime >= Time.current %>
+              <% if datetime >= Time.current && Date.current.since(2.months) >= datetime %>
                 <li class="time-schedule-cell">
                   <%= link_to '', new_user_reservation_url(@user, :started_at => l(time,format: :shorttime),:week_day => week_day),remote:true %>
                 </li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, 'ミーティングスペース予約画面') %>
 
-<div class="container">  
+<div class="container mb-5">  
   <div class="text-center my-5">
     <p class="mb-0">Meeting Spaceの予約</p>
     <h2 class="d-inline-block border-bottom border-dark mb-5">RESERVATION</h2>
@@ -23,13 +23,12 @@
     </div>
     <div id="show_user_reservation" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>
   </div>
-  <hr class="mb-5">
-  <div class="row">
+  <div class="d-flex mb-3">
     <div class="reservation_week_form">
       <%= render 'reservation_week' %>
     </div>
     
-    <div class="input-group date d-inline col-12 col-sm-1 my-auto text-center" id="datetimepicker" data-target-input="nearest">
+    <div class="input-group date d-inline col-1 my-auto text-center" id="datetimepicker" data-target-input="nearest">
       <input type="hidden" class="datetimepicker-input" data-target="#datetimepicker"/>
       <div class="input-group-append d-inline" data-target="#datetimepicker" data-toggle="datetimepicker">
         <button type="submit" class="ml-3" id="callender"><i class="far fa-calendar-alt btn btn-secondary"></i></button>
@@ -37,16 +36,6 @@
     </div>
   </div>
   
-  <div class="reservation_status_list">
-    <div class="can_reservation"> 
-      <div></div>
-      <p>予約できます</p>
-    </div>
-    <div class="can_not_reservation">
-      <div></div>
-      <p>予約できません</p>
-    </div>
-  </div>
   <div class="reservation_schedule_form table-responsive rounded rounded-lg">
     <div class="reservation_week_form_table">
       <%= render 'reservation_week_tabale_th' %>
@@ -81,6 +70,8 @@ $(function(){
   if(isMac && window.matchMedia( "(min-device-width: 1025px)" ).matches) {
     $('.reservation_week_form_table').css('padding-right',"16.9px");
   }
+  
+  $('.reservation_week_form_table_body').scrollTop(600);
   
 });    
     


### PR DESCRIPTION
ミーティングスペースの修正を行いました。
・一覧の下の空白削除
・週間表示修正、位置修正
・予約できない部分の色を少し黒く
・予約可能、不可能削除
・スクロールのデフォルト位置を午前８時前に設定
・タイムスケジュール表とブラウザ下面が接していたため、スペースをつける
・予約登録を２ヶ月先までに限定